### PR TITLE
Fix NPE and remove unnecessary screen capture

### DIFF
--- a/shift/build.gradle
+++ b/shift/build.gradle
@@ -13,7 +13,7 @@ ext {
     siteUrl = 'https://github.com/coursera/shift'
     gitUrl = 'https://github.com/coursera/shift'
 
-    libraryVersion = '1.1.1'
+    libraryVersion = '1.1.2'
 
     developerId = 'stanleyfung'
     developerName = 'Stanley Fung'

--- a/shift/src/main/java/org/coursera/android/shift/ShiftLauncherView.java
+++ b/shift/src/main/java/org/coursera/android/shift/ShiftLauncherView.java
@@ -60,10 +60,7 @@ public class ShiftLauncherView {
             if (tabsFragment != null && tabsFragment.isVisible()) {
                 return;
             }
-            if (ShiftManager.getInstance().getVisibilityClient().isVisible()) {
-                captureScreen(activity);
-                showTabsFragment(activity);
-            }
+            showTabsFragment(activity);
         }
     }
 
@@ -111,11 +108,15 @@ public class ShiftLauncherView {
 
     private void hideFragments(FragmentActivity activity) {
         ShiftIconFragment shiftIconFragment = getIconFragment(activity);
-        shiftIconFragment.hide();
+        if (shiftIconFragment != null) {
+            shiftIconFragment.hide();
+        }
     }
 
     private void showFragments(FragmentActivity activity) {
         ShiftIconFragment shiftIconFragment = getIconFragment(activity);
-        shiftIconFragment.show();
+        if (shiftIconFragment != null) {
+            shiftIconFragment.show();
+        }
     }
 }


### PR DESCRIPTION
For some reason, calling showShiftMenu() would also cause Shift to take a screenshot. Since showShiftMenu() is usually called when the floating icon isn't shown, this would result in a NullPointerException.
